### PR TITLE
Pull runner image from registry.gitlab.com instead of Docker Hub

### DIFF
--- a/lib/action/step/start_runner.rb
+++ b/lib/action/step/start_runner.rb
@@ -5,7 +5,7 @@ module GitlabPipelineAction
     class StartRunner < Base
       RunnerInvalid = Class.new(StandardError)
 
-      GITLAB_RUNNER_IMAGE = 'gitlab/gitlab-runner:v17.9.0'
+      GITLAB_RUNNER_IMAGE = 'registry.gitlab.com/gitlab-org/gitlab-runner:v17.9.0'
 
       def execute
         runner_config_template_path = "#{File.expand_path('../config', __dir__)}/gitlab_runner_config_template.toml"


### PR DESCRIPTION
This change should help with some issues due to the Docker Hub pull rate limits as the gitlab registry doesn't have them