### PR TITLE
Add job links to job summaries

### DIFF
--- a/lib/action/step/create_summary.rb
+++ b/lib/action/step/create_summary.rb
@@ -51,7 +51,7 @@ module GitlabPipelineAction
           next if summary.nil?
 
           <<~DESC
-            ### #{elem[:job].name}
+            ### [#{elem[:job].name}](#{elem[:job].web_url})
 
             #{summary}
           DESC

--- a/spec/action/step/create_summary_spec.rb
+++ b/spec/action/step/create_summary_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe GitlabPipelineAction::Step::CreateSummary do
     allow(pipeline).to receive_messages(web_url: 'some_web_url', duration: 50, detailed_status: detailed_status, id: 1)
     allow(detailed_status).to receive(:text).and_return('Passed')
     allow(gitlab_client).to receive(:pipeline_jobs).and_return([job])
-    allow(job).to receive_messages(id: 1, name: 'build')
+    allow(job).to receive_messages(id: 1, name: 'build', web_url: 'some_job_url')
     allow(gitlab_client).to receive(:job_trace).and_return(
       <<~TRACE
         Some job output
@@ -46,7 +46,7 @@ RSpec.describe GitlabPipelineAction::Step::CreateSummary do
       <<~DESC
         ## Job summaries
 
-        ### build
+        ### [build](some_job_url)
 
         Content of the GLPA summary
       DESC
@@ -84,7 +84,7 @@ RSpec.describe GitlabPipelineAction::Step::CreateSummary do
         <<~DESC
           ## Job summaries
 
-          ### build
+          ### [build](some_job_url)
 
           Content of timestamped summary
         DESC


### PR DESCRIPTION
Changing the job name to a link to the job provides faster navigation to these jobs as you don't need to visit the pipeline and search the job you want to look at