### PR TITLE
Pull runner image only if not already present

### DIFF
--- a/lib/action/step/start_runner.rb
+++ b/lib/action/step/start_runner.rb
@@ -11,7 +11,10 @@ module GitlabPipelineAction
         runner_config_template_path = "#{File.expand_path('../config', __dir__)}/gitlab_runner_config_template.toml"
         runner_config_template = File.read(runner_config_template_path)
 
-        Docker::Image.create('fromImage' => GITLAB_RUNNER_IMAGE)
+        unless Docker::Image.exist?(GITLAB_RUNNER_IMAGE)
+          puts "Pulling #{GITLAB_RUNNER_IMAGE}"
+          Docker::Image.create('fromImage' => GITLAB_RUNNER_IMAGE)
+        end
         container = Docker::Container.create(
           'Image' => GITLAB_RUNNER_IMAGE,
           'HostConfig' => {


### PR DESCRIPTION
If the image is already present, we can skip the pull step because we use versioned images that don't change and don't need to be re-pulled regularly. Therefore we can benefit from a small performance improvement by skipping the pull if the image is already present.

Closes #141 